### PR TITLE
Fix vimeo URL check

### DIFF
--- a/src/lib/functions.js
+++ b/src/lib/functions.js
@@ -51,7 +51,7 @@ export function isInteger(value) {
  * @return {boolean}
  */
 export function isVimeoUrl(url) {
-    return (/^(https?:)?\/\/(player.)?vimeo.com/).test(url);
+    return (/^(https?:)?\/\/(player.)?vimeo.com(?=$|\/)/).test(url);
 }
 
 /**

--- a/test/functions-test.js
+++ b/test/functions-test.js
@@ -41,6 +41,10 @@ test('isVimeoUrl identifies *.vimeo.com only', (t) => {
     t.true(isVimeoUrl('https://player.vimeo.com') === true);
     t.true(isVimeoUrl('https://notvimeo.com') === false);
     t.true(isVimeoUrl('https://vimeo.someone.com') === false);
+    t.true(isVimeoUrl('https://player.vimeo.com/video/123') === true);
+    t.true(isVimeoUrl('https://vimeo.com/2') === true);
+    t.true(isVimeoUrl('https://vimeo.com.evil.net') === false);
+    t.true(isVimeoUrl('http://player.vimeo.com.evil.com') === false);
 });
 
 test('getVimeoUrl correctly returns a url from the embed parameters', (t) => {


### PR DESCRIPTION
This ensures we are properly validating the hostname to not allow domains that are subdomains of other domains.