### PR TITLE
Minor update to docs for private videos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1139,7 +1139,7 @@ an object passed to the `Vimeo.Player` constructor.
 
 option      | default  | description
 ----------- | -------- | -----------
-id _or_ url |          | **Required.** Either the id or the url of the video.
+id _or_ url |          | **Required.** Either the id or the url of the video (private videos require passing the url).
 autopause   | `true`   | Pause this video automatically when another one plays.
 autoplay    | `false`  | Automatically start playback of the video. Note that this won’t work on some devices.
 byline      | `true`   | Show the byline on the video.


### PR DESCRIPTION
After a lot of trial and error, it appears that private videos can only be loaded by passing the url. Figured it would be good to call this out in the docs.