### PR TITLE
fix(postmessage): safety check

### DIFF
--- a/src/lib/postmessage.js
+++ b/src/lib/postmessage.js
@@ -28,7 +28,7 @@ export function parseMessageData(data) {
  * @return {void}
  */
 export function postMessage(player, method, params) {
-    if (!player.element.contentWindow.postMessage) {
+    if (!player.element.contentWindow || !player.element.contentWindow.postMessage) {
         return;
     }
 


### PR DESCRIPTION
Under some circumstances, for example with videojs, this method can be called while the `player.element.contentWindow` is already destroyed and this throws an exception;