### PR TITLE
support for the `background` parameter

### DIFF
--- a/src/lib/embed.js
+++ b/src/lib/embed.js
@@ -19,7 +19,8 @@ const oEmbedParameters = [
     'autopause',
     'loop',
     'responsive',
-    'speed'
+    'speed',
+    'background'
 ];
 
 /**


### PR DESCRIPTION
Add support for the `background` in the iframe embed parameters


Fixes #170 .
