### PR TITLE
Remove resize conditional in embed.js

### DIFF
--- a/src/lib/embed.js
+++ b/src/lib/embed.js
@@ -181,11 +181,10 @@ export function resizeEmbeds(parent = document) {
                 continue;
             }
 
+            // Change padding-bottom of the enclosing div to accommodate
+            // card carousel without distorting aspect ratio
             const space = iframes[i].parentElement;
-
-            if (space && space.className.indexOf('vimeo-space') !== -1) {
-                space.style.paddingBottom = `${event.data.data[0].bottom}px`;
-            }
+            space.style.paddingBottom = `${event.data.data[0].bottom}px`;
 
             break;
         }

--- a/src/lib/embed.js
+++ b/src/lib/embed.js
@@ -170,6 +170,7 @@ export function resizeEmbeds(parent = document) {
             return;
         }
 
+        // 'spacechange' is fired only on embeds with cards
         if (!event.data || event.data.event !== 'spacechange') {
             return;
         }

--- a/src/player.js
+++ b/src/player.js
@@ -875,7 +875,7 @@ class Player {
     }
 }
 
-if (!isNode) {
+if (!isNode && !window.Vimeo.Player) {
     initializeEmbeds();
     resizeEmbeds();
 }


### PR DESCRIPTION
`vimeo-space` is no longer used as the responsive player embed code contains an enclosing div in all cases. Hence this conditional can be removed.
