### PR TITLE
Check for Vimeo object 

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -875,7 +875,9 @@ class Player {
     }
 }
 
-if (!isNode && !window.Vimeo.Player) {
+// Setup embed only if this is not a node environment
+// and if there is no existing Vimeo Player object
+if (!isNode && (window.Vimeo && !window.Vimeo.Player)) {
     initializeEmbeds();
     resizeEmbeds();
 }


### PR DESCRIPTION
This change adds an additional check to look for window.Vimeo before checking for a player instance.

Fixes #238 .
