### PR TITLE
Enable adding/removing one handler across multiple events

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,18 @@ var onPlay = function(data) {
 player.on('play', onPlay);
 ```
 
+You can also create a handler that listens to multiple events by passing them as an array. For example:
+
+```js
+var eventList = ['progress', 'seeked', 'bufferstart'];
+var logEvent = function(data) {
+    console.log(data);
+}
+
+// Add a handler across multiple events.
+player.on(eventList, logEvent);
+```
+
 ### off(event: string, callback?: function): void
 
 Remove an event listener for the specified event. Will remove all listeners for
@@ -363,6 +375,21 @@ player.off('play', onPlay);
 // Alternatively, `off` can be called with just the event name to remove all
 // listeners.
 player.off('play');
+```
+
+You can remove a handler across multiple events by passing them as an array. In this case, you must specify the callback to be removed.
+For example:
+
+```js
+var eventList = ['progress', 'seeked', 'bufferstart'];
+var logEvent = function(data) {
+    console.log(data);
+}
+
+player.on(eventList, logEvent);
+
+// `off` can be called with list of event names to remove one listener across many events
+player.off(eventList, logEvent);
 ```
 
 ### loadVideo(id: number): Promise&lt;number, (TypeError|PasswordError|Error)&gt;

--- a/src/player.js
+++ b/src/player.js
@@ -206,13 +206,20 @@ class Player {
      * callback with a single parameter, `data`, that contains the data for
      * that event.
      *
-     * @param {string} eventName The name of the event.
+     * @param {string|string[]} eventName The name or list of names of the event
      * @param {function(*)} callback The function to call when the event fires.
      * @return {void}
      */
     on(eventName, callback) {
         if (!eventName) {
-            throw new TypeError('You must pass an event name.');
+            throw new TypeError('You must pass an event name or array of event names.');
+        }
+
+        // Add an event listener for multiple events passed as an array
+        if (eventName instanceof Array && eventName.length > 0) {
+            eventName.forEach((event) => {
+                this.on(event, callback);
+            })
         }
 
         if (!callback) {
@@ -239,13 +246,23 @@ class Player {
      * listeners for that event if a `callback` isn’t passed, or only that
      * specific callback if it is passed.
      *
-     * @param {string} eventName The name of the event.
+     * @param {string|string[]} eventName The name or list of names of the event
      * @param {function} [callback] The specific callback to remove.
      * @return {void}
      */
     off(eventName, callback) {
         if (!eventName) {
             throw new TypeError('You must pass an event name.');
+        }
+
+        // Remove one callback across multiple events
+        if (eventName instanceof Array && eventName.length > 0) {
+            if (!callback) {
+                throw new TypeError('You must pass a callback to remove across multiple events');
+            }
+            eventName.forEach((event) => {
+                this.off(event, callback);
+            })
         }
 
         if (callback && typeof callback !== 'function') {


### PR DESCRIPTION
This change adds the ability to add/remove listeners for multiple events at a time by passing event names in an array. 

Fixes #232 .
