### PR TITLE
Reject ready promise on 403

### DIFF
--- a/src/lib/embed.js
+++ b/src/lib/embed.js
@@ -58,7 +58,7 @@ export function getOEmbedData(videoUrl, params = {}, element) {
             throw new TypeError(`“${videoUrl}” is not a vimeo.com url.`);
         }
 
-        let url = `https://api-2489.ci.vimeows.com/api/oembed.json?url=${encodeURIComponent(videoUrl)}&domain=${window.location.hostname}`;
+        let url = `https://vimeo.com/api/oembed.json?url=${encodeURIComponent(videoUrl)}&domain=${window.location.hostname}`;
 
         for (const param in params) {
             if (params.hasOwnProperty(param)) {
@@ -82,10 +82,8 @@ export function getOEmbedData(videoUrl, params = {}, element) {
 
             try {
                 const json = JSON.parse(xhr.responseText);    
-                
                 // Check api response for 403 on oembed
                 if (json['domain_status_code'] === 403) {
-
                     // We still want to create the embed to give users visual feedback
                     createEmbed(json, element);
                     return reject(new Error(`“${videoUrl}” is not embeddable.`));

--- a/src/lib/embed.js
+++ b/src/lib/embed.js
@@ -46,10 +46,36 @@ export function getOEmbedParameters(element, defaults = {}) {
 }
 
 /**
+ * Create an embed from oEmbed data inside an element.
+ *
+ * @param {object} data The oEmbed data.
+ * @param {HTMLElement} element The element to put the iframe in.
+ * @return {HTMLIFrameElement} The iframe embed.
+ */
+export function createEmbed({ html }, element) {
+    if (!element) {
+        throw new TypeError('An element must be provided');
+    }
+
+    if (element.getAttribute('data-vimeo-initialized') !== null) {
+        return element.querySelector('iframe');
+    }
+
+    const div = document.createElement('div');
+    div.innerHTML = html;
+
+    element.appendChild(div.firstChild);
+    element.setAttribute('data-vimeo-initialized', 'true');
+
+    return element.querySelector('iframe');
+}
+
+/**
  * Make an oEmbed call for the specified URL.
  *
  * @param {string} videoUrl The vimeo.com url for the video.
  * @param {Object} [params] Parameters to pass to oEmbed.
+ * @param {HTMLElement} element The element.
  * @return {Promise}
  */
 export function getOEmbedData(videoUrl, params = {}, element) {
@@ -81,15 +107,16 @@ export function getOEmbedData(videoUrl, params = {}, element) {
             }
 
             try {
-                const json = JSON.parse(xhr.responseText);    
+                const json = JSON.parse(xhr.responseText);
                 // Check api response for 403 on oembed
-                if (json['domain_status_code'] === 403) {
+                if (json.domain_status_code === 403) {
                     // We still want to create the embed to give users visual feedback
                     createEmbed(json, element);
-                    return reject(new Error(`“${videoUrl}” is not embeddable.`));
-                } 
+                    reject(new Error(`“${videoUrl}” is not embeddable.`));
+                    return;
+                }
 
-               resolve(json);
+                resolve(json);
             }
             catch (error) {
                 reject(error);
@@ -103,31 +130,6 @@ export function getOEmbedData(videoUrl, params = {}, element) {
 
         xhr.send();
     });
-}
-
-/**
- * Create an embed from oEmbed data inside an element.
- *
- * @param {object} data The oEmbed data.
- * @param {HTMLElement} element The element to put the iframe in.
- * @return {HTMLIFrameElement} The iframe embed.
- */
-export function createEmbed({ html }, element) {
-    if (!element) {
-        throw new TypeError('An element must be provided');
-    }
-
-    if (element.getAttribute('data-vimeo-initialized') !== null) {
-        return element.querySelector('iframe');
-    }
-
-    const div = document.createElement('div');
-    div.innerHTML = html;
-
-    element.appendChild(div.firstChild);
-    element.setAttribute('data-vimeo-initialized', 'true');
-
-    return element.querySelector('iframe');
 }
 
 /**

--- a/src/player.js
+++ b/src/player.js
@@ -96,7 +96,7 @@ class Player {
                 const params = getOEmbedParameters(element, options);
                 const url = getVimeoUrl(params);
 
-                getOEmbedData(url, params).then((data) => {
+                getOEmbedData(url, params, element).then((data) => {
                     const iframe = createEmbed(data, element);
                     // Overwrite element with the new iframe,
                     // but store reference to the original element


### PR DESCRIPTION
This PR gives users the ability to properly detect errors on player instantiation. We detect errors as follows:

`var player = new Vimeo.Player('made-in-ny', options);
player.ready().catch((error) => {
        console.log('ERROR', error);
});
`

Before this change, a 403 (privacy settings error) wouldn't be caught. Now, we throw the error to allow devs to give their own visual feedback. This currently is using a CI link, which will be updated to production before being merged.  

Fixes https://github.com/vimeo/player.js/issues/165
