### PR TITLE
Add dnt to oEmbedParameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1283,6 +1283,7 @@ autoplay    | `false`  | Automatically start playback of the video. Note that th
 background  | `false`  | Enable the player's background mode which hides the controls, autoplays and loops the video (available to  Plus, PRO, or Business members).
 byline      | `true`   | Show the byline on the video.
 color       | `00adef` | Specify the color of the video controls. Colors may be overridden by the embed settings of the video.
+dnt         | `false`  | Block the player from tracking any session data, including cookies.
 height      |          | The exact height of the video. Defaults to the height of the largest available version of the video.
 loop        | `false`  | Play the video again when it reaches the end.
 responsive  | `false`  | Resize according their parent element (experimental)

--- a/src/lib/embed.js
+++ b/src/lib/embed.js
@@ -10,6 +10,7 @@ const oEmbedParameters = [
     'background',
     'byline',
     'color',
+    'dnt',
     'height',
     'id',
     'loop',


### PR DESCRIPTION
Just adding `dnt` to the available `oEmbedParameters` as this is something I need.

It is listed as an available player parameter here:
https://help.vimeo.com/hc/en-us/articles/360001494447-Using-Player-Parameters

I think this is straightforward enough that I don't need to add any tests as it seems to already be covered, but if there is anything else I need to do please let me know.

Thanks!
