### PR TITLE
Remove unused domain param

### DIFF
--- a/src/lib/embed.js
+++ b/src/lib/embed.js
@@ -87,7 +87,7 @@ export function getOEmbedData(videoUrl, params = {}, element) {
             throw new TypeError(`“${videoUrl}” is not a vimeo.com url.`);
         }
 
-        let url = `https://vimeo.com/api/oembed.json?url=${encodeURIComponent(videoUrl)}&domain=${window.location.hostname}`;
+        let url = `https://vimeo.com/api/oembed.json?url=${encodeURIComponent(videoUrl)}`;
 
         for (const param in params) {
             if (params.hasOwnProperty(param)) {


### PR DESCRIPTION
Fixes #406

We no longer use the `domain` param to detect this.