### PR TITLE
Add fullscreen lib for iframe

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,7 +12,7 @@ module.exports = {
     },
     settings: {
         'polyfills': [
-            'promises'
+            'Promise'
         ]
     }
 };

--- a/src/lib/fullscreen.js
+++ b/src/lib/fullscreen.js
@@ -1,0 +1,157 @@
+/* MIT License
+
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+Terms */
+
+const fn = (function() {
+    let val;
+
+    const fnMap = [
+        [
+            'requestFullscreen',
+            'exitFullscreen',
+            'fullscreenElement',
+            'fullscreenEnabled',
+            'fullscreenchange',
+            'fullscreenerror'
+        ],
+        // New WebKit
+        [
+            'webkitRequestFullscreen',
+            'webkitExitFullscreen',
+            'webkitFullscreenElement',
+            'webkitFullscreenEnabled',
+            'webkitfullscreenchange',
+            'webkitfullscreenerror'
+
+        ],
+        // Old WebKit
+        [
+            'webkitRequestFullScreen',
+            'webkitCancelFullScreen',
+            'webkitCurrentFullScreenElement',
+            'webkitCancelFullScreen',
+            'webkitfullscreenchange',
+            'webkitfullscreenerror'
+
+        ],
+        [
+            'mozRequestFullScreen',
+            'mozCancelFullScreen',
+            'mozFullScreenElement',
+            'mozFullScreenEnabled',
+            'mozfullscreenchange',
+            'mozfullscreenerror'
+        ],
+        [
+            'msRequestFullscreen',
+            'msExitFullscreen',
+            'msFullscreenElement',
+            'msFullscreenEnabled',
+            'MSFullscreenChange',
+            'MSFullscreenError'
+        ]
+    ];
+
+    let i = 0;
+    const l = fnMap.length;
+    const ret = {};
+
+    for (; i < l; i++) {
+        val = fnMap[i];
+        if (val && val[1] in document) {
+            for (i = 0; i < val.length; i++) {
+                ret[fnMap[0][i]] = val[i];
+            }
+            return ret;
+        }
+    }
+
+    return false;
+}());
+
+const eventNameMap = {
+    fullscreenchange: fn.fullscreenchange,
+    fullscreenerror: fn.fullscreenerror
+};
+
+const screenfull = {
+    request(element) {
+        return new Promise((resolve, reject) => {
+            const onFullScreenEntered = function() {
+                screenfull.off('fullscreenchange', onFullScreenEntered);
+                resolve();
+            };
+
+            screenfull.on('fullscreenchange', onFullScreenEntered);
+
+            element = element || document.documentElement;
+
+            const returnPromise = element[fn.requestFullscreen]();
+            if (returnPromise instanceof Promise) {
+                returnPromise.then(onFullScreenEntered).catch(reject);
+            }
+        });
+    },
+    exit() {
+        return new Promise((resolve, reject) => {
+            if (!screenfull.isFullscreen) {
+                resolve();
+                return;
+            }
+
+            const onFullScreenExit = function() {
+                screenfull.off('fullscreenchange', onFullScreenExit);
+                resolve();
+            };
+
+            screenfull.on('fullscreenchange', onFullScreenExit);
+
+            const returnPromise = document[fn.exitFullscreen]();
+            if (returnPromise instanceof Promise) {
+                returnPromise.then(onFullScreenExit).catch(reject);
+            }
+        });
+    },
+    on(event, callback) {
+        const eventName = eventNameMap[event];
+        if (eventName) {
+            document.addEventListener(eventName, callback);
+        }
+    },
+    off(event, callback) {
+        const eventName = eventNameMap[event];
+        if (eventName) {
+            document.removeEventListener(eventName, callback);
+        }
+    }
+};
+
+Object.defineProperties(screenfull, {
+    isFullscreen: {
+        get() {
+            return Boolean(document[fn.fullscreenElement]);
+        }
+    },
+    element: {
+        enumerable: true,
+        get() {
+            return document[fn.fullscreenElement];
+        }
+    },
+    isEnabled: {
+        enumerable: true,
+        get() {
+            // Coerce to boolean in case of old WebKit
+            return Boolean(document[fn.fullscreenEnabled]);
+        }
+    }
+});
+
+export default screenfull;

--- a/src/player.js
+++ b/src/player.js
@@ -7,6 +7,7 @@ import { storeCallback, getCallbacks, removeCallback, swapCallbacks } from './li
 import { getMethodName, isDomElement, isVimeoUrl, getVimeoUrl, isNode } from './lib/functions';
 import { getOEmbedParameters, getOEmbedData, createEmbed, initializeEmbeds, resizeEmbeds } from './lib/embed';
 import { parseMessageData, postMessage, processData } from './lib/postmessage';
+import screenfull from './lib/fullscreen.js';
 
 const playerMap = new WeakMap();
 const readyMap = new WeakMap();
@@ -228,6 +229,13 @@ class Player {
             throw new TypeError('The callback must be a function.');
         }
 
+        if (screenfull.isEnabled && (
+            eventName === 'fullscreenchange' || eventName === 'fullscreenerror'
+        )) {
+            screenfull.on(eventName, callback);
+            return;
+        }
+
         const callbacks = getCallbacks(this, `event:${eventName}`);
         if (callbacks.length === 0) {
             this.callMethod('addEventListener', eventName).catch(() => {
@@ -255,6 +263,13 @@ class Player {
 
         if (callback && typeof callback !== 'function') {
             throw new TypeError('The callback must be a function.');
+        }
+
+        if (screenfull.isEnabled && (
+            eventName === 'fullscreenchange' || eventName === 'fullscreenerror'
+        )) {
+            screenfull.off(eventName, callback);
+            return;
         }
 
         const lastCallback = removeCallback(this, `event:${eventName}`, callback);
@@ -442,6 +457,9 @@ class Player {
      * @return {Promise}
      */
     requestFullscreen() {
+        if (screenfull.isEnabled) {
+            return screenfull.request(this.element);
+        }
         return this.callMethod('requestFullscreen');
     }
 
@@ -450,6 +468,9 @@ class Player {
      * @return {Promise}
      */
     exitFullscreen() {
+        if (screenfull.isEnabled) {
+            return screenfull.exit();
+        }
         return this.callMethod('exitFullscreen');
     }
 
@@ -458,6 +479,9 @@ class Player {
      * @return {Promise}
      */
     getFullscreen() {
+        if (screenfull.isEnabled) {
+            return Promise.resolve(screenfull.isFullscreen);
+        }
         return this.get('fullscreen');
     }
 


### PR DESCRIPTION
Fixes #584

This change adds fullscreen helpers to request and exit fullscreen, add and remove event listeners for `fullscreenchange`. If the w3c fullscreen API is available it will be used, if not the fullscreen methods will fallback to try and request the internal player fullscreen methods via postMessage. This is needed for iOS which goes fullscreen via the `<video>` element.

