### PR TITLE
update documentation for loadVideo

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,7 +435,11 @@ Load a new video into this embed. The promise will be resolved if the video is
 successfully loaded, or it will be rejected if it could not be loaded.
 
 ```js
-player.loadVideo(76979871).then(function(id) {
+player.loadVideo({
+                    id: 76979871,
+                    h:'37110065a5'
+                })
+.then(function(id) {
     // the video successfully loaded
 }).catch(function(error) {
     switch (error.name) {


### PR DESCRIPTION
since new uploaded video come with ?h=, not only video ID anymore, so when call player.loadVideo, user should pass options as argument, not number any more.

<!--
Please make sure to read our contributing guidelines first. Please try to limit the scope, provide a general description of the changes, and remember, it’s up to you to convince us to merge it.

If this fixes an open issue, link to it in the following way: `Fixes #321`.

New features and bug fixes should come with tests.
-->

Fixes #.
