### PR TITLE
Add interactive params embed option

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ color             | `00adef` | Specify the color of the video controls. Colors m
 controls          | `true`   | This parameter will hide all elements in the player (play bar, sharing buttons, etc) for a chromeless experience. ⚠️Warning: When using this parameter, the play bar and UI will be hidden. To start playback for your viewers, you'll need to either enable autoplay or use our player SDK to start and control playback. (available to Plus, PRO, or Business members)
 dnt               | `false`  | Block the player from tracking any session data, including cookies.
 height            |          | The exact height of the video. Defaults to the height of the largest available version of the video.
-interactiveparams |          | For interactive videos only that utilize live elements, this will contain key/value pairs for dynamic values to be passed into the live element. Ex: `[key1=value1,key2=value2]` 
+interactiveparams |          | Key-value pairs representing dynamic parameters that are utilized on interactive videos with live elements. Ex: `key1=value1,key2=value2`.More context on live elements can be found through [Wirewax](https://devhub.wirewax.com/docs/live-element).
 keyboard          | `true`   | Allows for keyboard input to trigger player events. If false, will ignore keyboard input. Tabbing will still be supported in either mode.
 loop              | `false`  | Play the video again when it reaches the end.
 maxheight         |          | Same as height, but video will not exceed the native size of the video.

--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ color             | `00adef` | Specify the color of the video controls. Colors m
 controls          | `true`   | This parameter will hide all elements in the player (play bar, sharing buttons, etc) for a chromeless experience. ⚠️Warning: When using this parameter, the play bar and UI will be hidden. To start playback for your viewers, you'll need to either enable autoplay or use our player SDK to start and control playback. (available to Plus, PRO, or Business members)
 dnt               | `false`  | Block the player from tracking any session data, including cookies.
 height            |          | The exact height of the video. Defaults to the height of the largest available version of the video.
-interactiveparams |          | Key-value pairs representing dynamic parameters that are utilized on interactive videos with live elements. Ex: `key1=value1,key2=value2`.More context on live elements can be found through [Wirewax](https://devhub.wirewax.com/docs/live-element).
+interactiveparams |          | Key-value pairs representing dynamic parameters that are utilized on interactive videos with live elements. Ex: `key1=value1,key2=value2`.
 keyboard          | `true`   | Allows for keyboard input to trigger player events. If false, will ignore keyboard input. Tabbing will still be supported in either mode.
 loop              | `false`  | Play the video again when it reaches the end.
 maxheight         |          | Same as height, but video will not exceed the native size of the video.

--- a/README.md
+++ b/README.md
@@ -329,32 +329,33 @@ lightbox opened from clicking on a thumbnail, for example).
 These options are available to use as `data-vimeo-` attributes on elements or as
 an object passed to the `Vimeo.Player` constructor. More information on embed options can be found in the [Vimeo Help Center](https://help.vimeo.com/hc/en-us/articles/360001494447-Using-Player-Parameters).
 
-option      | default  | description
------------ | -------- | -----------
-id _or_ url |          | **Required.** Either the id or the URL of the video. Note that if the video [privacy settings](https://vimeo.zendesk.com/hc/en-us/articles/224817847-Privacy-settings-overview) are "Private", instead of an id, a URL that includes the `h` parameter must be provided.
-autopause   | `true`   | Pause this video automatically when another one plays.
-autoplay    | `false`  | Automatically start playback of the video. Note that this won’t work on some devices.
-background  | `false`  | Enable the player's background mode which hides the controls, autoplays and loops the video (available to  Plus, PRO, or Business members).
-byline      | `true`   | Show the byline on the video.
-color       | `00adef` | Specify the color of the video controls. Colors may be overridden by the embed settings of the video.
-controls    | `true`   | This parameter will hide all elements in the player (play bar, sharing buttons, etc) for a chromeless experience. ⚠️Warning: When using this parameter, the play bar and UI will be hidden. To start playback for your viewers, you'll need to either enable autoplay or use our player SDK to start and control playback. (available to Plus, PRO, or Business members)
-dnt         | `false`  | Block the player from tracking any session data, including cookies.
-height      |          | The exact height of the video. Defaults to the height of the largest available version of the video.
-keyboard    | `true`   | Allows for keyboard input to trigger player events. If false, will ignore keyboard input. Tabbing will still be supported in either mode.
-loop        | `false`  | Play the video again when it reaches the end.
-maxheight   |          | Same as height, but video will not exceed the native size of the video.
-maxwidth    |          | Same as width, but video will not exceed the native size of the video.
-muted       | `false`  | Mute this video on load. Required to autoplay in certain browsers.
-pip         | `false`   | Show the picture-in-picture button in the controlbar and enable the picture-in-picture API.
-playsinline | `true`   | Play video inline on mobile devices, to automatically go fullscreen on playback set this parameter to `false`.
-portrait    | `true`   | Show the portrait on the video.
-quality     |          | Vimeo Plus, PRO, and Business members can default an embedded video to a specific quality on desktop. Possible values: `4K`, `2K`, `1080p`, `720p`, `540p`, `360p` and `240p` https://help.vimeo.com/hc/en-us/articles/224983008-Setting-default-quality-for-embedded-videos
-responsive  | `false`  | Resize according to the parent element (experimental)
-speed       | `false`  | Show the speed controls in the preferences menu and enable playback rate API (available to PRO and Business accounts).
-texttrack   |          | Turn captions/subtitles on for a specific language by default. If you enter a language preference that hasn't yet been uploaded for your particular video, the text track parameter will be ignored, and your embedded video may load with CC or subtitles disabled by default. Supports lowercase language code (such as: `fr`, `es`, `de`, `en`). You can find a full list of popular language codes [here](https://www.andiamo.co.uk/resources/iso-language-codes/).
-title       | `true`   | Show the title on the video.
-transparent | `true`   | The responsive player and transparent background are enabled by default, to disable set this parameter to `false`.
-width       |          | The exact width of the video. Defaults to the width of the largest available version of the video.
+option            | default  | description
+----------------- | -------- | -----------
+id _or_ url       |          | **Required.** Either the id or the URL of the video. Note that if the video [privacy settings](https://vimeo.zendesk.com/hc/en-us/articles/224817847-Privacy-settings-overview) are "Private", instead of an id, a URL that includes the `h` parameter must be provided.
+autopause         | `true`   | Pause this video automatically when another one plays.
+autoplay          | `false`  | Automatically start playback of the video. Note that this won’t work on some devices.
+background        | `false`  | Enable the player's background mode which hides the controls, autoplays and loops the video (available to  Plus, PRO, or Business members).
+byline            | `true`   | Show the byline on the video.
+color             | `00adef` | Specify the color of the video controls. Colors may be overridden by the embed settings of the video.
+controls          | `true`   | This parameter will hide all elements in the player (play bar, sharing buttons, etc) for a chromeless experience. ⚠️Warning: When using this parameter, the play bar and UI will be hidden. To start playback for your viewers, you'll need to either enable autoplay or use our player SDK to start and control playback. (available to Plus, PRO, or Business members)
+dnt               | `false`  | Block the player from tracking any session data, including cookies.
+height            |          | The exact height of the video. Defaults to the height of the largest available version of the video.
+interactiveparams |          | For interactive videos only that utilize live elements, this will contain key/value pairs for dynamic values to be passed into the live element. Ex: `[key1=value1,key2=value2]` 
+keyboard          | `true`   | Allows for keyboard input to trigger player events. If false, will ignore keyboard input. Tabbing will still be supported in either mode.
+loop              | `false`  | Play the video again when it reaches the end.
+maxheight         |          | Same as height, but video will not exceed the native size of the video.
+maxwidth          |          | Same as width, but video will not exceed the native size of the video.
+muted             | `false`  | Mute this video on load. Required to autoplay in certain browsers.
+pip               | `false`   | Show the picture-in-picture button in the controlbar and enable the picture-in-picture API.
+playsinline       | `true`   | Play video inline on mobile devices, to automatically go fullscreen on playback set this parameter to `false`.
+portrait          | `true`   | Show the portrait on the video.
+quality           |          | Vimeo Plus, PRO, and Business members can default an embedded video to a specific quality on desktop. Possible values: `4K`, `2K`, `1080p`, `720p`, `540p`, `360p` and `240p` https://help.vimeo.com/hc/en-us/articles/224983008-Setting-default-quality-for-embedded-videos
+responsive        | `false`  | Resize according to the parent element (experimental)
+speed             | `false`  | Show the speed controls in the preferences menu and enable playback rate API (available to PRO and Business accounts).
+texttrack         |          | Turn captions/subtitles on for a specific language by default. If you enter a language preference that hasn't yet been uploaded for your particular video, the text track parameter will be ignored, and your embedded video may load with CC or subtitles disabled by default. Supports lowercase language code (such as: `fr`, `es`, `de`, `en`). You can find a full list of popular language codes [here](https://www.andiamo.co.uk/resources/iso-language-codes/).
+title             | `true`   | Show the title on the video.
+transparent       | `true`   | The responsive player and transparent background are enabled by default, to disable set this parameter to `false`.
+width             |          | The exact width of the video. Defaults to the width of the largest available version of the video.
 
 
 

--- a/src/lib/embed.js
+++ b/src/lib/embed.js
@@ -14,6 +14,7 @@ const oEmbedParameters = [
     'dnt',
     'height',
     'id',
+    'interactiveparams',
     'keyboard',
     'loop',
     'maxheight',


### PR DESCRIPTION
Adds the option to pass in the forthcoming `interactiveparams` option to the player, as well as updates documentation.