### PR TITLE
Use npm publish for deploy workflow

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -16,6 +16,6 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           scope: '@vimeo'
       - run: yarn --frozen-lockfile
-      - run: yarn publish --new-version ${{ github.event.release.tag_name }}
+      - run: yarn publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_VIMEO_PUBLISH_TOKEN }}

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -16,6 +16,6 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           scope: '@vimeo'
       - run: yarn --frozen-lockfile
-      - run: yarn publish
+      - run: yarn publish --access=public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_VIMEO_PUBLISH_TOKEN }}

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -5,15 +5,16 @@ on:
     types: [published]
 
 jobs:
-  publish:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
-          # Setup .npmrc file to publish to npm
+          node-version: '16.x'
           registry-url: 'https://registry.npmjs.org'
+          scope: '@vimeo'
       - run: yarn --frozen-lockfile
       - run: yarn publish --new-version ${{ github.event.release.tag_name }}
         env:


### PR DESCRIPTION
Follows GitHub docs on publishing to npm using yarn: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages#publishing-packages-using-yarn

Configures `scope` during setup node step, adds `--access=public` flag to publish step.

Hopefully fixes `error Couldn't publish package: "https://registry.npmjs.org/@vimeo%2fplayer: Not found"`