### PR TITLE
Upload test coverage on PR merge

### DIFF
--- a/.github/workflows/pr-merge.yml
+++ b/.github/workflows/pr-merge.yml
@@ -1,0 +1,33 @@
+name: Upload Coverage
+on:
+    push:
+        branches:
+            - master
+jobs:
+    upload:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v3
+
+            - name: Set Node.js 16.x
+              uses: actions/setup-node@v3
+              with:
+                  node-version: 16.x
+
+            - name: Install packages
+              uses: borales/actions-yarn@v4
+              with:
+                  cmd: install
+
+            - name: Test
+              uses: borales/actions-yarn@v4
+              with:
+                  cmd: test
+
+            - name: Generate test coverage
+              uses: borales/actions-yarn@v4
+              with:
+                  cmd: report-coverage
+
+            - name: Upload coverage reports to Codecov
+              uses: codecov/codecov-action@v3


### PR DESCRIPTION
Uploads coverage to CodeCov for the master branch when a new PR is merged.