### PR TITLE
Change import to type import for events.ts

### DIFF
--- a/types/events.ts
+++ b/types/events.ts
@@ -1,4 +1,4 @@
-import {
+import type {
     Seconds,
     VolumeLevel,
     PlaybackRate,


### PR DESCRIPTION
Fixes type error
`'Seconds' is a type and must be imported using a type-only import when 'verbatimModuleSyntax' is enabled.ts(1484)`

<!--
Please make sure to read our contributing guidelines first. Please try to limit the scope, provide a general description of the changes, and remember, it’s up to you to convince us to merge it.

If this fixes an open issue, link to it in the following way: `Fixes #321`.

New features and bug fixes should come with tests.
-->

Fixes #.
