### PR TITLE
feat: add disable_context_menu embed option

### DIFF
--- a/src/lib/embed.js
+++ b/src/lib/embed.js
@@ -21,6 +21,7 @@ const oEmbedParameters = [
     'color',
     'colors',
     'controls',
+    'disable_context_menu',
     'dnt',
     'end_time',
     'fullscreen',

--- a/types/formats.ts
+++ b/types/formats.ts
@@ -143,6 +143,12 @@ export type VimeoEmbedParameters = {
     controls?: boolean;
 
     /**
+     * Whether to disable the custom right-click context menu (which shows options like "Open debug panel", "Copy debug info", etc.)
+     * @default false
+     */
+    disable_context_menu?: boolean;
+
+    /**
      * Whether to prevent the player from tracking session data, including setting cookies
      * @default false
      */


### PR DESCRIPTION
## Summary

- Adds \`disable_context_menu\` to the \`oEmbedParameters\` allowlist in \`src/lib/embed.js\`, enabling \`data-vimeo-disable-context-menu="true"\` and \`new Player(el, { disable_context_menu: true })\` usage
- Adds \`disable_context_menu?: boolean\` to \`VimeoEmbedParameters\` in \`types/formats.ts\` with JSDoc

## Context

The Vimeo player ships a custom right-click context menu (showing "Open debug panel", "Copy debug info", etc.). Some embedders want to suppress it entirely. This parameter passes through to the player iframe as a URL param; the player-side implementation is in the companion PR: vimeows/player#11363.

## Behaviour

| Value | Effect |
|-------|--------|
| absent / \`false\` (default) | Custom context menu works as today |
| \`true\` | Context menu is never shown, regardless of user interaction |

## Test plan

- [ ] \`new Player(el, { id: 123, disable_context_menu: true })\` — right-click on player produces no custom menu
- [ ] \`new Player(el, { id: 123 })\` — right-click still shows custom menu
- [ ] \`data-vimeo-disable-context-menu="true"\` attribute on div — custom menu suppressed
- [ ] TypeScript: \`disable_context_menu\` autocompletes and accepts \`boolean\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 27db2ca34134b8f68addf6654ef7fd8ff5e94be3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->