### PR TITLE
fix: pin GitHub Actions to SHA for supply chain security

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,44 +4,44 @@ jobs:
     run:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
             - name: Set Node.js 18.x
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
               with:
                   node-version: 18.x
 
             - name: Install packages
-              uses: borales/actions-yarn@v4
+              uses: borales/actions-yarn@97ba8bebfe5b549bb7999261698a52a81fd62f1b # v4
               with:
                   cmd: install --frozen-lockfile
 
             - name: Build production bundle
-              uses: borales/actions-yarn@v4
+              uses: borales/actions-yarn@97ba8bebfe5b549bb7999261698a52a81fd62f1b # v4
               with:
                   cmd: build
 
             - name: Lint
-              uses: borales/actions-yarn@v4
+              uses: borales/actions-yarn@97ba8bebfe5b549bb7999261698a52a81fd62f1b # v4
               with:
                   cmd: lint
 
             - name: Check types
-              uses: borales/actions-yarn@v4
+              uses: borales/actions-yarn@97ba8bebfe5b549bb7999261698a52a81fd62f1b # v4
               with:
                   cmd: check-types
 
             - name: Test
-              uses: borales/actions-yarn@v4
+              uses: borales/actions-yarn@97ba8bebfe5b549bb7999261698a52a81fd62f1b # v4
               with:
                   cmd: test
 
             - name: Generate test coverage
-              uses: borales/actions-yarn@v4
+              uses: borales/actions-yarn@97ba8bebfe5b549bb7999261698a52a81fd62f1b # v4
               with:
                   cmd: report-coverage
 
             - name: Upload coverage reports to Codecov
-              uses: codecov/codecov-action@v5
+              uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
               with:
                   token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/pr-merge.yml
+++ b/.github/workflows/pr-merge.yml
@@ -7,29 +7,29 @@ jobs:
     upload:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
             - name: Set Node.js 18.x
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
               with:
                   node-version: 18.x
 
             - name: Install packages
-              uses: borales/actions-yarn@v4
+              uses: borales/actions-yarn@97ba8bebfe5b549bb7999261698a52a81fd62f1b # v4
               with:
                   cmd: install --frozen-lockfile
 
             - name: Test
-              uses: borales/actions-yarn@v4
+              uses: borales/actions-yarn@97ba8bebfe5b549bb7999261698a52a81fd62f1b # v4
               with:
                   cmd: test
 
             - name: Generate test coverage
-              uses: borales/actions-yarn@v4
+              uses: borales/actions-yarn@97ba8bebfe5b549bb7999261698a52a81fd62f1b # v4
               with:
                   cmd: report-coverage
 
             - name: Upload coverage reports to Codecov
-              uses: codecov/codecov-action@v5
+              uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
               with:
                   token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -8,9 +8,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       # Setup .npmrc file to publish to npm
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '18.x'
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
## Summary

Pin all GitHub Actions to full commit SHAs for supply chain security.

Actions referenced by tag or branch have been resolved to their commit SHA, with the original ref preserved as an inline comment. Where a sub-action had unpinned transitive dependencies, the action was upgraded to the closest newer version where all sub-actions are fully pinned.
