### PR TITLE
TimingSrcConnector: force pause after fallback attempt at muted autoplay fails

### DIFF
--- a/src/lib/timing-src-connector.js
+++ b/src/lib/timing-src-connector.js
@@ -130,7 +130,10 @@ export class TimingSrcConnector extends EventTarget {
                         .catch(async(err) => {
                             if (err.name === 'NotAllowedError' && options.autoPlayMuted) {
                                 await player.setMuted(true);
-                                await player.play().catch((err2) => console.error('Couldn\'t play the video from TimingSrcConnector. Error:', err2));
+                                await player.play().catch(async err2 => {
+                                    console.error('Couldn\'t play the video from TimingSrcConnector. Error:', err2);
+                                    await player.pause();
+                                });
                             }
                         });
                     this.updatePlayer(timingObject, player, options);


### PR DESCRIPTION
After an autoplay failure due to a `NotAllowed` error, the player currently tries muting the video and playing again. In some circumstances (for example, on iOS with low-power mode enabled), autoplay will still be blocked, causing the player to get stuck in a weird state -- for an example of the playback getting stalled, can test using https://codepen.io/Alex-Paseltiner/pen/yyVjVBP on an iOS device with low-power mode enabled:

<img width="250" alt="IMG_6266" src="https://github.com/user-attachments/assets/4bdd09f1-ddae-49b8-bc61-ab4615c93886" />

Fix by pausing the video after catching a second `NotAllowed` error.