### PR TITLE
fix: preserve default name for incomplete error events

### DIFF
--- a/src/lib/postmessage.js
+++ b/src/lib/postmessage.js
@@ -73,7 +73,9 @@ export function processData(player, data) {
 
             promises.forEach((promise) => {
                 const error = new Error(data.data.message);
-                error.name = data.data.name;
+                if (data.data.name) {
+                    error.name = data.data.name;
+                }
 
                 promise.reject(error);
                 removeCallback(player, data.data.method, promise);

--- a/test/postmessage-test.js
+++ b/test/postmessage-test.js
@@ -164,3 +164,27 @@ test('processData rejects a method promise on an error event', async (t) => {
     t.is(error.name, 'TypeError');
     t.is(error.message, 'The color should be 3- or 6-digit hex value.');
 });
+
+test('processData keeps the default error name when the event omits it', async (t) => {
+    const player = { element: {} };
+    const callback = {};
+    const methodPromise = new Promise((resolve, reject) => {
+        callback.resolve = resolve;
+        callback.reject = reject;
+    });
+
+    storeCallback(player, 'getColor', callback);
+
+    processData(player, {
+        event: 'error',
+        data: {
+            method: 'getColor',
+            message: 'The player returned an incomplete error event.'
+        }
+    });
+
+    t.true(getCallbacks(player, 'getColor').length === 0);
+    const error = await t.throwsAsync(methodPromise);
+    t.is(error.name, 'Error');
+    t.is(error.message, 'The player returned an incomplete error event.');
+});


### PR DESCRIPTION
## Summary

- Keep the native `Error` name when an iframe error event omits its `name` field.
- Add a focused regression test for the incomplete event payload.

## Root cause

`processData` unconditionally assigned `data.data.name` to a newly created `Error`. When the iframe omitted that field, the assignment replaced the native `"Error"` name with `undefined`, which could break downstream error handling.

The change only overrides `error.name` when a name was supplied. Existing named errors keep their current behavior.

Fixes #1148.

## Validation

- Focused `postmessage` tests: 11 passed.
- ESLint: passed.
- TypeScript declaration check: passed.
- Production build: passed.
- `git diff --check`: passed.

The complete local `yarn test` run reaches an existing network-dependent embed test failure and two timeouts. The same failure reproduces on an unmodified `master@ce600ad772be` snapshot in this environment; the focused suite, lint, types, and build all pass for this change.
