### PR TITLE
fix: detect Node in VM contexts

### DIFF
--- a/src/lib/functions.js
+++ b/src/lib/functions.js
@@ -6,9 +6,9 @@
  * Check to see this is a Node environment.
  * @type {boolean}
  */
-/* global global */
-export const isNode = typeof global !== 'undefined' &&
-  ({}).toString.call(global) === '[object global]';
+/* global document, process */
+export const isNode = typeof process !== 'undefined' &&
+  process.versions != null && process.versions.node != null;
 
 /**
  * Check to see if this is a Bun environment.
@@ -35,7 +35,8 @@ export const isCloudflareWorker = typeof WebSocketPair === 'function' && typeof 
  * Check if this is a server runtime
  * @type {boolean}
  */
-export const isServerRuntime = isNode || isBun || isDeno || isCloudflareWorker;
+export const isServerRuntime = typeof document === 'undefined' &&
+  (isNode || isBun || isDeno || isCloudflareWorker);
 
 /**
  * Get the name of the method for a given getter or setter.

--- a/test/functions-test.js
+++ b/test/functions-test.js
@@ -1,6 +1,55 @@
 import test from 'ava';
+import vm from 'node:vm';
+import { versions } from 'node:process';
+import { rollup } from 'rollup';
 import html from './helpers/html';
 import { getMethodName, isDomElement, isInteger, isVimeoUrl, isVimeoEmbed, getVimeoUrl, getOembedDomain, findIframeBySourceWindow } from '../src/lib/functions';
+
+async function createRuntimeLoader() {
+    const bundle = await rollup({ input: 'src/lib/functions.js' });
+    const { output } = await bundle.generate({ format: 'iife', name: 'runtimeFlags' });
+    await bundle.close();
+    const runtimeCode = output[0].code;
+
+    return (processValue, documentValue) => {
+        const context = vm.createContext({
+            process: processValue,
+            document: documentValue,
+            caches: {},
+            WebSocketPair: undefined
+        });
+
+        context.global = context;
+        vm.runInContext(runtimeCode, context);
+
+        return {
+            globalTag: vm.runInContext('Object.prototype.toString.call(global)', context),
+            isNode: context.runtimeFlags.isNode,
+            isServerRuntime: context.runtimeFlags.isServerRuntime
+        };
+    };
+}
+
+test('isNode detects Node inside VM contexts without matching browser shims', async (t) => {
+    const loadRuntimeFlags = await createRuntimeLoader();
+    const nodeVm = loadRuntimeFlags({ versions });
+    const browser = loadRuntimeFlags(undefined);
+    const browserShim = loadRuntimeFlags({ browser: true, versions: {} });
+    const minimalBrowserShim = loadRuntimeFlags({ browser: true });
+    const hybridRenderer = loadRuntimeFlags({ versions }, {});
+
+    t.is(nodeVm.globalTag, '[object Object]');
+    t.true(nodeVm.isNode);
+    t.true(nodeVm.isServerRuntime);
+    t.false(browser.isNode);
+    t.false(browser.isServerRuntime);
+    t.false(browserShim.isNode);
+    t.false(browserShim.isServerRuntime);
+    t.false(minimalBrowserShim.isNode);
+    t.false(minimalBrowserShim.isServerRuntime);
+    t.true(hybridRenderer.isNode);
+    t.false(hybridRenderer.isServerRuntime);
+});
 
 test('getMethodName properly formats the method name', (t) => {
     t.true(getMethodName('color', 'get') === 'getColor');


### PR DESCRIPTION
## Summary

- detect Node through `process.versions.node` instead of a realm-specific `global` object tag
- preserve browser process-shim behavior and the existing Bun, Deno, and Cloudflare Worker checks
- add a regression that bundles the real source and evaluates it in isolated Node VM and browser-like contexts

Fixes #1153.

## Testing

- Node 18.20.8 focused VM regression: 1 test passed
- Node 18.20.8 `test/functions-test.js`: 11 tests passed
- modified-file ESLint
- TypeScript check
- production Rollup build
- full AVA suite matched untouched `master`; both had the same two live Vimeo oEmbed/network failures
- `git diff --check`
